### PR TITLE
Use pods for volume provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/miekg/dns v1.1.45 // indirect
@@ -31,6 +32,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -42,7 +42,7 @@ const (
 	provisionerName           = "microk8s.io/hostpath"
 	exponentialBackOffOnError = false
 	failedRetryThreshold      = 5
-	defaultBusyboxImage       = "busybox:latest"
+	defaultBusyboxImage       = "busybox:1.34.1"
 )
 
 var kubeconfigFilePath = os.Getenv("KUBECONFIG")

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -139,6 +139,7 @@ func (p *hostPathProvisioner) Delete(ctx context.Context, volume *v1.PersistentV
 func main() {
 	syscall.Umask(0)
 
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	// Use the provided kubeconfig file, or

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -51,4 +51,4 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: microk8s.io/hostpath
-
+volumeBindingMode: WaitForFirstConsumer

--- a/manifests/test-sts.yaml
+++ b/manifests/test-sts.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 2 # by default is 1
+  minReadySeconds: 10 # by default is 0
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - nginx
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: volume
+          mountPath: /usr/share/nginx/html
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: "Delete"
+  volumeClaimTemplates:
+  - metadata:
+      name: volume
+    spec:
+      storageClassName: microk8s-hostpath
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
### Summary

Use temporary busybox pods to provision volumes instead of running local commands.

### Notes

- The default `VolumeBindingMode` changes to `WaitForFirstConsumer` as part of this change. This allows the provisioner to know the selected node for a PVC, and schedule the pod accordingly. The previous default was `VolumeBindingImmediate`. It will still work, but might fail when pods with node affinity rules are scheduled.
- Provisioned volumes now get the `NodeAffinity` property set. This fixes a number of issues with workloads losing their data.
- Also needs extra RBAC rules to list nodes, as well as create, get, and delete pods. Upgrading to the new version is a manual process, so this does not affect existing clusters.