### PR TITLE
Allow multiple PV directory

### DIFF
--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -84,7 +84,7 @@ func NewHostPathProvisioner(clientset *kubernetes.Clientset) controller.Provisio
 		klog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
 	}
 
-	pvDir := os.Getenv("DEFAULT_PV_DIR")
+	pvDir := os.Getenv("PV_DIR")
 	if pvDir == "" {
 		klog.Fatal("env variable PV_DIR must be set so that this provisioner knows where to place its data")
 	}

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -194,9 +194,7 @@ waitLoop:
 // Provision creates a storage asset and returns a PV object representing it.
 func (p *hostPathProvisioner) Provision(ctx context.Context, options controller.ProvisionOptions) (*v1.PersistentVolume, controller.ProvisioningState, error) {
 	pvDir := p.pvDir
-	storageClassPvDir, ok := options.StorageClass.Parameters["pvDir"]
-
-	if ok {
+	if storageClassPvDir, ok := options.StorageClass.Parameters["pvDir"]; ok {
 		pvDir = storageClassPvDir
 	}
 	path := path.Join(pvDir, fmt.Sprintf("%s-%s-%s", options.PVC.Namespace, options.PVC.Name, options.PVName))

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -39,7 +39,7 @@ import (
 const (
 	resyncPeriod = 15 * time.Second
 	// The provisioner name "microk8s.io/hostpath" must be the one used in the storage class manifest
-	provisionerName           = "balchu.io/hostpath"
+	provisionerName           = "microk8s.io/hostpath"
 	exponentialBackOffOnError = false
 	failedRetryThreshold      = 5
 	defaultBusyboxImage       = "busybox:1.34.1"

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: balchu-hostpath-provisioner
+  name: hostpath-provisioner
   labels:
     k8s-app: hostpath-provisioner
   namespace: kube-system
@@ -12,13 +12,11 @@ spec:
 
   selector:
     matchLabels:
-      k8s-app: balchu-hostpath-provisioner
-
+      k8s-app: hostpath-provisioner
   template:
     metadata:
       labels:
-        k8s-app: balchu-hostpath-provisioner
-
+        k8s-app: hostpath-provisioner
     spec:
       containers:
         - name: hostpath-provisioner

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: hostpath-provisioner
-          image: balchu/hostpath-provisioner:1.1.1
+          image: cdkbot/hostpath-provisioner:1.1.1
           env:
             - name: NODE_NAME
               valueFrom:
@@ -30,7 +30,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: DEFAULT_PV_DIR
+            - name: PV_DIR
               value: /var/snap/microk8s/common/default-storage
 ---
 kind: StorageClass

--- a/manifests/storage.yaml
+++ b/manifests/storage.yaml
@@ -1,7 +1,7 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hostpath-provisioner
+  name: balchu-hostpath-provisioner
   labels:
     k8s-app: hostpath-provisioner
   namespace: kube-system
@@ -12,37 +12,28 @@ spec:
 
   selector:
     matchLabels:
-      k8s-app: hostpath-provisioner
+      k8s-app: balchu-hostpath-provisioner
 
   template:
     metadata:
       labels:
-        k8s-app: hostpath-provisioner
+        k8s-app: balchu-hostpath-provisioner
 
     spec:
       containers:
         - name: hostpath-provisioner
-          image: kjackal/hostpath-provisioner:latest
+          image: balchu/hostpath-provisioner:1.1.1
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-
-            - name: PV_DIR
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DEFAULT_PV_DIR
               value: /var/snap/microk8s/common/default-storage
-
-#            - name: PV_RECLAIM_POLICY
-#              value: Retain
-
-          volumeMounts:
-            - name: pv-volume
-              mountPath: /var/snap/microk8s/common/default-storage
-
-      volumes:
-        - name: pv-volume
-          hostPath:
-            path: /var/snap/microk8s/common/default-storage
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -51,4 +42,15 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: microk8s.io/hostpath
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ssd-hostpath
+provisioner: microk8s.io/hostpath
+reclaimPolicy: Delete
+parameters:
+  pvDir: /tmp/ssd-storage
 volumeBindingMode: WaitForFirstConsumer

--- a/manifests/test-claim.yaml
+++ b/manifests/test-claim.yaml
@@ -3,7 +3,19 @@ apiVersion: v1
 metadata:
   name: hostpath-test-claim
 spec:
-#  storageClassName: "hostpath"
+  storageClassName: "default-path"
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: hostpath-test-claim2
+spec:
+  storageClassName: "ssd-hostpath"
   accessModes:
     - ReadWriteMany
   resources:

--- a/manifests/test-claim.yaml
+++ b/manifests/test-claim.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: hostpath-test-claim
 spec:
-  storageClassName: "default-path"
+  storageClassName: "microk8s-hostpath"
   accessModes:
     - ReadWriteMany
   resources:

--- a/manifests/test-pod.yaml
+++ b/manifests/test-pod.yaml
@@ -15,3 +15,21 @@ spec:
     - name: hostpath-volume
       persistentVolumeClaim:
         claimName: hostpath-test-claim
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hostpath-test-pod2
+spec:
+  containers:
+  - name: hostpath-test-container2
+    image: gcr.io/google_containers/busybox:1.24
+    command: ["/bin/sh", "-c", "while true; do date >> /mnt/dates; sleep 10; done"]
+    volumeMounts:
+      - name: hostpath-volume
+        mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: hostpath-volume
+      persistentVolumeClaim:
+        claimName: hostpath-test-claim2       


### PR DESCRIPTION
Fixes https://github.com/canonical/microk8s-core-addons/issues/26

Allows one to specify different `StorageClass` to point to different host paths.

example:

``` yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: slow-disk-hostpath
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
provisioner: microk8s.io/hostpath
parameters:
  pvDir: /slow-disk/ssd-storage
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Retain
---
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: ssd-hostpath
provisioner: microk8s.io/hostpath
reclaimPolicy: Delete
parameters:
  pvDir: /fast-disk/ssd-storage
volumeBindingMode: WaitForFirstConsumer