### PR TITLE
Build images for ppc64le architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ TAG_LATEST=$(IMAGE):latest
 all: hostpath-provisioner
 
 # Build Docker images
-build-images: build-image-amd64 build-image-arm64 build-image-s390x
+build-images: build-image-amd64 build-image-arm64 build-image-s390x build-image-ppc64le
 build-image-%:
 	docker build -t ${TAG_VERSION}-$* . --build-arg arch=$*
 
 # Push Docker images
-push-images: push-image-amd64 push-image-arm64 push-image-s390x
+push-images: push-image-amd64 push-image-arm64 push-image-s390x push-image-ppc64le
 push-image-%: build-image-%
 	docker image push $(TAG_VERSION)-$*
 
@@ -34,10 +34,11 @@ push-image-%: build-image-%
 manifest: manifest-$(VERSION)
 manifest-%: push-images
 	docker manifest rm $(IMAGE):$* || true
-	docker manifest create $(IMAGE):$* --amend $(TAG_VERSION)-amd64 --amend $(TAG_VERSION)-arm64 --amend $(TAG_VERSION)-s390x
+	docker manifest create $(IMAGE):$* --amend $(TAG_VERSION)-amd64 --amend $(TAG_VERSION)-arm64 --amend $(TAG_VERSION)-s390x --amend $(TAG_VERSION)-ppc64le
 	docker manifest annotate $(IMAGE):$* $(TAG_VERSION)-amd64 --arch=amd64
 	docker manifest annotate $(IMAGE):$* $(TAG_VERSION)-arm64 --arch=arm64
 	docker manifest annotate $(IMAGE):$* $(TAG_VERSION)-s390x --arch=s390x
+	docker manifest annotate $(IMAGE):$* $(TAG_VERSION)-ppc64le --arch=ppc64le
 	docker manifest push $(IMAGE):$*
 
 # Build

--- a/README.md
+++ b/README.md
@@ -4,20 +4,19 @@ This is the hostpath-provisioner used in [MicroK8s](https://microk8s.io) to prov
 
 It is based on [the demo hostpath-provisioner from kubernetes-incubator](https://github.com/kubernetes-incubator/external-storage/tree/master/docs/demo/hostpath-provisioner), and contains modifications proposed [here](https://github.com/MaZderMind/hostpath-provisioner).
 
-
 ## Build Docker images
 
 ```bash
 docker login
-make manifest VERSION=1.1.0
+make manifest VERSION=1.3.0
 
 # push latest tag
-make manifest-latest VERSION=1.1.0
+make manifest-latest VERSION=1.3.0
 ```
 
 ## Release
 
-Docker images for the hostpath-provisioner are released to [DockerHub](https://hub.docker.com/r/cdkbot/hostpath-provisioner), and they are available for amd64, arm64, s390x architectures.
+Docker images for the hostpath-provisioner are released to [DockerHub](https://hub.docker.com/r/cdkbot/hostpath-provisioner), and they are available for amd64, arm64, s390x, ppc64le architectures.
 
 ## Build for development
 


### PR DESCRIPTION
## Summary

Build Docker images for ppc64le architectures as well.